### PR TITLE
external-node-postgres-1 creating Error

### DIFF
--- a/external-node/testnet-external-node.yml
+++ b/external-node/testnet-external-node.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - testnet-prometheus-data:/prometheus
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-    expose:
+    ports:
       - 9090
   grafana:
     image: grafana/grafana:9.3.6
@@ -48,7 +48,7 @@ services:
         ]
     environment:
       - POSTGRES_PASSWORD=notsecurepassword
-      - PGPORT=5430
+      - PGPORT=5432
   external-node:
     image: "matterlabs/external-node:2.0-v24.6.0"
     depends_on:


### PR DESCRIPTION
To resolve the Container external-node-postgres-1 creating Error error received with default settings Changed expose to ports to make the services accessible from outside the container . Set the PGPORT environment variable to the default PostgreSQL port 5432.