### PR TITLE
bug fix: `testnet-external-node.yml`

### DIFF
--- a/external-node/testnet-external-node.yml
+++ b/external-node/testnet-external-node.yml
@@ -1,4 +1,4 @@
-name: "testnet-node"
+x-name: &name "testnet-node"
 services:
   prometheus:
     image: prom/prometheus:v2.35.0
@@ -95,7 +95,7 @@ services:
       EN_MAIN_NODE_URL: https://api.testnet.abs.xyz
       EN_L1_CHAIN_ID: 11155111
       EN_L2_CHAIN_ID: 11124
-      EN_PRUNING_ENABLED: true
+      EN_PRUNING_ENABLED: "true"
 
       EN_STATE_CACHE_PATH: "./db/ext-node/state_keeper"
       EN_MERKLE_TREE_PATH: "./db/ext-node/lightweight"


### PR DESCRIPTION
# Description

This PR fixes two validation errors in the `testnet-external-node.yml` file:
-  Converts boolean environment variable `EN_PRUNING_ENABLED` to a string type
-  Updates the `name` field by moving it to a proper extension field with `x-` prefix

## Issues

Encountered the following errors when trying to run the `docker-compose` command:
- ```bash
    ERROR: The Compose file './testnet-external-node.yml' is invalid because:
    services.external-node.environment.EN_PRUNING_ENABLED contains true, which is an invalid type, it should be a string, number, or a null
- ```bash
    ERROR: The Compose file './testnet-external-node.yml' is invalid because:
    'name' does not match any of the regexes: '^x-'

## Changes Made

1. Environment Variable Type Fix:
   - Changed `EN_PRUNING_ENABLED: true` to `EN_PRUNING_ENABLED: "true"` to comply with Docker Compose environment variable type requirements

2. Name Field Format:
   - Moved top-level `name: "testnet-node"` to proper extension field format:
     ```yaml
     x-name: &name "testnet-node"

## Reason for Changes

- Docker Compose requires environment variables to be strings, not booleans.
- The name field must follow the `x-` extension field format according to Docker Compose specifications.