### PR TITLE
fix: changes mainnet name in docker-compose file

### DIFF
--- a/external-node/mainnet-external-node.yml
+++ b/external-node/mainnet-external-node.yml
@@ -1,4 +1,4 @@
-name: "testnet-node"
+name: "mainnet-node"
 services:
   prometheus:
     image: prom/prometheus:v2.35.0


### PR DESCRIPTION
* I noticed that the `docker-compose` file for mainnet has `name` set to `testnet-node`.
* This renames it to `mainnet-node.`