### PR TITLE
added control for size per PV

### DIFF
--- a/charts/abstract-node/Chart.yaml
+++ b/charts/abstract-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: abstract-node
 description: External node for syncing and serving blockchain data for Abstract
-version: 0.1.6
+version: 0.1.7
 type: application
 icon: https://abstract-assets.abs.xyz/icons/light.png
 keywords:

--- a/charts/abstract-node/templates/statefulset.yaml
+++ b/charts/abstract-node/templates/statefulset.yaml
@@ -182,7 +182,7 @@ spec:
         storageClassName: {{ .Values.persistence.storageClassName }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }}
+            storage: {{ .Values.persistence.lightweight.size | quote }}
     - metadata:
         name: statekeeper
         labels:
@@ -196,5 +196,5 @@ spec:
         storageClassName: {{ .Values.persistence.storageClassName }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }}
+            storage: {{ .Values.persistence.statekeeper.size | quote }}
 {{- end }}

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -226,7 +226,7 @@ database:
   secretName: ""
   secretKey: "uri"
 
-node: 
+node:
   ## The URL of the Ethereum client.
   ##
   ethClientUrl: "https://eth.drpc.org"
@@ -251,8 +251,11 @@ persistence:
   storageClassName: ""
   accessModes:
     - ReadWriteOnce
-  size: 10Gi
   annotations: {}
+  lightweight:
+    size: 10Gi
+  statekeeper:
+    size: 10Gi
 
 ## Node labels for pod assignment
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `abstract-node` Helm chart configuration to introduce new storage options and increment the version. It modifies the persistence settings and adjusts the storage references in the `statefulset.yaml` template.

### Detailed summary
- Updated `version` in `charts/abstract-node/Chart.yaml` from `0.1.6` to `0.1.7`.
- Added `lightweight` and `statekeeper` storage configurations in `charts/abstract-node/values.yaml`.
- Adjusted storage requests in `charts/abstract-node/templates/statefulset.yaml` to reference new sizes for `lightweight` and `statekeeper`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->