### PR TITLE
chore: bump node version to v27

### DIFF
--- a/charts/abstract-node/Chart.yaml
+++ b/charts/abstract-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: abstract-node
 description: External node for syncing and serving blockchain data for Abstract
-version: 0.1.7
+version: 0.1.8
 type: application
 icon: https://abstract-assets.abs.xyz/icons/light.png
 keywords:
@@ -11,7 +11,7 @@ keywords:
 home: https://abs.xyz
 sources:
   - https://github.com/matter-labs/zksync-era
-appVersion: "26.8.5"
+appVersion: "27.2.0"
 
 dependencies:
   - name: common

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -79,7 +79,7 @@ image:
   registry: docker.io
   repository: matterlabs/external-node
   pullPolicy: IfNotPresent
-  tag: "v26.8.5"
+  tag: "v27.2.0"
 
 # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/docker/.env.mainnet
+++ b/docker/.env.mainnet
@@ -1,6 +1,6 @@
 # Don't change these values unless you know what you're doing
 NETWORK=mainnet
-EN_VERSION=v26.8.5
+EN_VERSION=v27.2.0
 EN_MAIN_NODE_URL=https://api.mainnet.abs.xyz
 EN_L1_CHAIN_ID=1
 EN_L2_CHAIN_ID=2741

--- a/docker/external-node.yml
+++ b/docker/external-node.yml
@@ -50,7 +50,7 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD:-notsecurepassword}
       - PGPORT=5430
   external-node:
-    image: "matterlabs/external-node:${EN_VERSION:-v26.8.5}"
+    image: "matterlabs/external-node:${EN_VERSION:-v27.2.0}"
     entrypoint: ["/usr/bin/entrypoint.sh"]
     restart: always
     depends_on:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the versioning of the `external-node` and related configurations to `v27.2.0`, enhancing the deployment settings and ensuring compatibility with the latest features and fixes.

### Detailed summary
- Updated `EN_VERSION` in `docker/.env.mainnet` to `v27.2.0`.
- Changed `image` tag in `docker/external-node.yml` to `${EN_VERSION:-v27.2.0}`.
- Updated `tag` in `charts/abstract-node/values.yaml` to `v27.2.0`.
- Bumped `version` in `charts/abstract-node/Chart.yaml` to `0.1.8`.
- Changed `appVersion` in `charts/abstract-node/Chart.yaml` to `27.2.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->