### PR TITLE
add shutdown wrapper and node config knobs

### DIFF
--- a/charts/abstract-node/Chart.yaml
+++ b/charts/abstract-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: abstract-node
 description: External node for syncing and serving blockchain data for Abstract
-version: 0.1.36
+version: 0.1.37
 type: application
 icon: https://abstract-assets.abs.xyz/icons/light.png
 keywords:

--- a/charts/abstract-node/templates/statefulset.yaml
+++ b/charts/abstract-node/templates/statefulset.yaml
@@ -69,7 +69,37 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.args }}
+          {{- if .Values.shutdownWrapper.enabled }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              set -eu
+
+              child=0
+
+              forward_int() {
+                if [ "$child" -ne 0 ]; then
+                  echo "Forwarding SIGINT to child process ${child}"
+                  kill -INT "$child" 2>/dev/null || true
+                fi
+              }
+
+              trap 'forward_int' TERM
+              trap 'forward_int' INT
+
+              /usr/bin/entrypoint.sh "$@" &
+              child=$!
+
+              status=0
+              wait "$child" || status=$?
+              exit "$status"
+            - wrapper
+            {{- range .Values.args }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- else if .Values.args }}
           args:
             {{- range .Values.args }}
             - {{ . | quote }}
@@ -97,7 +127,7 @@ spec:
             - name: EN_ESTIMATE_GAS_ACCEPTABLE_OVERESTIMATION
               value: "5000"
             - name: DATABASE_POOL_SIZE
-              value: "10"
+              value: {{ .Values.database.poolSize | quote }}
             - name: EN_HTTP_PORT
               value: {{ .Values.rpc.http.port | quote }}
             - name: EN_WS_PORT
@@ -130,6 +160,14 @@ spec:
               value: "warn,zksync=info,zksync_web3_decl::client=error"
             - name: EN_API_NAMESPACES
               value: {{ .Values.rpc.api | quote }}
+            {{- if .Values.rpc.maxResponseBodySizeMb }}
+            - name: EN_MAX_RESPONSE_BODY_SIZE_MB
+              value: {{ .Values.rpc.maxResponseBodySizeMb | quote }}
+            {{- end }}
+            {{- if .Values.database.poolSizeMaster }}
+            - name: EN_DATABASE_MAX_CONNECTIONS_MASTER
+              value: {{ .Values.database.poolSizeMaster | quote }}
+            {{- end }}
             {{- if .Values.node.batchCommitDataGeneratorMode }}
             - name: EN_L1_BATCH_COMMIT_DATA_GENERATOR_MODE
               value: {{ .Values.node.batchCommitDataGeneratorMode | quote }}

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -81,6 +81,9 @@ image:
   pullPolicy: IfNotPresent
   tag: "v29.14.0"
 
+shutdownWrapper:
+  enabled: false
+
 # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 ## Provide a name in place of abstract-node for `app:` labels
@@ -153,6 +156,10 @@ rpc:
   ## API Namespaces available via RPC
   ##
   api: "eth,net,web3,debug,zks,pubsub"
+  ##
+  ## Maximum JSON-RPC response body size in MiB.
+  ##
+  maxResponseBodySizeMb: null
   ## RPC configuration.
   ##
   http:
@@ -242,6 +249,8 @@ resources: {}
 database:
   secretName: ""
   secretKey: "uri"
+  poolSize: 10
+  poolSizeMaster: null
 
 node:
   ## The URL of the Ethereum client.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `abstract-node` Helm chart, including a version bump and several new configuration options for shutdown behavior, RPC response size, and database connection pooling.

### Detailed summary
- Bumped `version` in `Chart.yaml` from `0.1.36` to `0.1.37`.
- Added `shutdownWrapper` configuration in `values.yaml` with `enabled` set to `false`.
- Introduced `maxResponseBodySizeMb` in `values.yaml`.
- Added `poolSize` and `poolSizeMaster` options in `values.yaml`.
- Modified `statefulset.yaml` to use `shutdownWrapper.enabled` for command execution.
- Added handling for signals in the shutdown wrapper script.
- Updated environment variables in `statefulset.yaml` to include new values for `EN_MAX_RESPONSE_BODY_SIZE_MB` and `EN_DATABASE_MAX_CONNECTIONS_MASTER`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->