### PR TITLE
feat(chart): add extra env support

### DIFF
--- a/charts/abstract-node/Chart.yaml
+++ b/charts/abstract-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: abstract-node
 description: External node for syncing and serving blockchain data for Abstract
-version: 0.1.37
+version: 0.1.38
 type: application
 icon: https://abstract-assets.abs.xyz/icons/light.png
 keywords:
@@ -11,7 +11,7 @@ keywords:
 home: https://abs.xyz
 sources:
   - https://github.com/matter-labs/zksync-era
-appVersion: "29.14.0"
+appVersion: "29.19.0"
 
 dependencies:
   - name: common

--- a/charts/abstract-node/templates/statefulset.yaml
+++ b/charts/abstract-node/templates/statefulset.yaml
@@ -222,6 +222,10 @@ spec:
             - name: EN_API_SEND_RAW_TX_SYNC_DEFAULT_TIMEOUT_MS
               value: {{ .Values.rpc.sendRawTxSyncDefaultTimeout | quote }}
             {{- end }}
+            {{- range $name, $value := .Values.node.extraEnv }}
+            - name: {{ $name | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
           ports:
           {{- if .Values.rpc.http.enabled }}
             - name: http

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -79,7 +79,7 @@ image:
   registry: docker.io
   repository: matterlabs/external-node
   pullPolicy: IfNotPresent
-  tag: "v29.14.0"
+  tag: "v29.19.0"
 
 shutdownWrapper:
   enabled: false
@@ -253,6 +253,10 @@ database:
   poolSizeMaster: null
 
 node:
+  ## Additional environment variables for the external node container.
+  ## Values are rendered as strings.
+  ##
+  extraEnv: {}
   ## The URL of the Ethereum client.
   ##
   ethClientUrl: "https://eth.drpc.org"


### PR DESCRIPTION
## What changed

- Bumped the abstract-node chart version from `0.1.37` to `0.1.38`.
- Updated the default external node app/image version from `29.14.0` / `v29.14.0` to `29.19.0` / `v29.19.0`.
- Added `node.extraEnv` so operators can append arbitrary environment variables to the external node container beyond the chart's preconfigured env vars.

## Impact

Chart users can now set additional node environment variables through values without needing to fork or patch the StatefulSet template.

## Validation

- `helm lint /private/tmp/abstract-node-chart-test.9mSFAy/abstract-node`
- `helm template abstract-node /private/tmp/abstract-node-chart-test.9mSFAy/abstract-node`
- `helm template abstract-node /private/tmp/abstract-node-chart-test.9mSFAy/abstract-node --set node.extraEnv.FOO=bar --set node.extraEnv.NUMERIC=123`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `abstract-node` Helm chart by adding support for additional environment variables, updating version numbers, and modifying configuration for the external node.

### Detailed summary
- Added support for `extraEnv` in `statefulset.yaml` to allow additional environment variables.
- Updated `tag` from `v29.14.0` to `v29.19.0` in `values.yaml`.
- Incremented `version` from `0.1.37` to `0.1.38` in `Chart.yaml`.
- Updated `appVersion` from `29.14.0` to `29.19.0` in `Chart.yaml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->