### PR TITLE
feat(chart): add external node ha mode

### DIFF
--- a/charts/abstract-node/Chart.yaml
+++ b/charts/abstract-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: abstract-node
 description: External node for syncing and serving blockchain data for Abstract
-version: 0.1.39
+version: 0.1.40
 type: application
 icon: https://abstract-assets.abs.xyz/icons/light.png
 keywords:

--- a/charts/abstract-node/templates/_helpers.tpl
+++ b/charts/abstract-node/templates/_helpers.tpl
@@ -60,3 +60,84 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+HA core StatefulSet / governing service name.
+*/}}
+{{- define "abstract-node.haCoreName" -}}
+{{- $name := include "common.names.fullname" . | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-core" $name -}}
+{{- end }}
+
+{{/*
+HA API Deployment name.
+*/}}
+{{- define "abstract-node.haApiName" -}}
+{{- $name := include "common.names.fullname" . | trunc 59 | trimSuffix "-" -}}
+{{- printf "%s-api" $name -}}
+{{- end }}
+
+{{/*
+Default HA core components. The tree API is included by default so API replicas can
+proxy proof requests to the singleton tree.
+*/}}
+{{- define "abstract-node.haCoreComponents" -}}
+{{- if .Values.ha.core.components -}}
+{{- .Values.ha.core.components -}}
+{{- else if .Values.ha.treeApi.enabled -}}
+core,tree,tree_fetcher,tree_api
+{{- else -}}
+core,tree,tree_fetcher
+{{- end -}}
+{{- end }}
+
+{{/*
+Default HA API components.
+*/}}
+{{- define "abstract-node.haApiComponents" -}}
+{{- default "api" .Values.ha.api.components -}}
+{{- end }}
+
+{{/*
+Render external node command / args, preserving the existing shutdown wrapper behavior.
+*/}}
+{{- define "abstract-node.nodeArgs" -}}
+{{- $root := .root -}}
+{{- $args := default (list) .args -}}
+{{- if $root.Values.shutdownWrapper.enabled }}
+command:
+  - /bin/sh
+  - -ec
+args:
+  - |
+    set -eu
+
+    child=0
+
+    forward_int() {
+      if [ "$child" -ne 0 ]; then
+        echo "Forwarding SIGINT to child process ${child}"
+        kill -INT "$child" 2>/dev/null || true
+      fi
+    }
+
+    trap 'forward_int' TERM
+    trap 'forward_int' INT
+
+    /usr/bin/entrypoint.sh "$@" &
+    child=$!
+
+    status=0
+    wait "$child" || status=$?
+    exit "$status"
+  - wrapper
+  {{- range $args }}
+  - {{ . | quote }}
+  {{- end }}
+{{- else if $args }}
+args:
+  {{- range $args }}
+  - {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/abstract-node/templates/deployment-api.yaml
+++ b/charts/abstract-node/templates/deployment-api.yaml
@@ -1,30 +1,23 @@
+{{- if .Values.ha.enabled }}
 ---
-apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
-kind: StatefulSet
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: {{ ternary (include "abstract-node.haCoreName" .) (include "common.names.fullname" .) .Values.ha.enabled }}
+  name: {{ include "abstract-node.haApiName" . }}
   labels:
-    {{- include "common.labels.statefulset" . | nindent 4 }}
-    {{- if .Values.ha.enabled }}
-    app.kubernetes.io/component: core
-    {{- end }}
+    {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
-  replicas: {{ ternary 1 .Values.global.replicaCount .Values.ha.enabled }}
-  podManagementPolicy: "Parallel"
+  replicas: {{ .Values.ha.api.replicaCount }}
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}
-      {{- if .Values.ha.enabled }}
-      app.kubernetes.io/component: core
-      {{- end }}
-  serviceName: {{ ternary (include "abstract-node.haCoreName" .) (include "common.names.fullname" .) .Values.ha.enabled }}
+      app.kubernetes.io/component: api
   template:
     metadata:
       labels:
         {{- include "common.labels.matchLabels" . | nindent 8 }}
-        {{- if .Values.ha.enabled }}
-        app.kubernetes.io/component: core
-        {{- end }}
+        app.kubernetes.io/component: api
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -55,35 +48,12 @@ spec:
     {{- end }}
       serviceAccountName: {{ include "common.names.serviceAccountName" . }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
-      {{- if .Values.consensus.enabled }}
-      initContainers:
-      - name: init-consensus-secrets
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command:
-        - "/bin/sh"
-        - "-c"
-        - >
-         if [ ! -f /consensus/secrets.yaml ]; then
-           /usr/bin/zksync_external_node generate-secrets > /consensus/secrets.yaml && 
-           echo 'Created secrets'
-         else
-           echo 'Secrets already exist'
-         fi
-        volumeMounts:
-        - name: consensus-secrets
-          mountPath: /consensus
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.ha.enabled }}
-          {{- $coreArgs := concat (list (printf "--components=%s" (include "abstract-node.haCoreComponents" .))) .Values.ha.core.extraArgs }}
-{{ include "abstract-node.nodeArgs" (dict "root" . "args" $coreArgs) | nindent 10 }}
-          {{- else }}
-{{ include "abstract-node.nodeArgs" (dict "root" . "args" .Values.args) | nindent 10 }}
-          {{- end }}
+          {{- $apiArgs := concat (list (printf "--components=%s" (include "abstract-node.haApiComponents" .))) .Values.ha.api.extraArgs }}
+{{ include "abstract-node.nodeArgs" (dict "root" . "args" $apiArgs) | nindent 10 }}
           env:
             - name: POD_IP
               valueFrom:
@@ -115,10 +85,6 @@ spec:
               value: {{ .Values.healthcheck.port | quote }}
             - name: EN_PROMETHEUS_PORT
               value: {{ .Values.metrics.port | quote }}
-            {{- if and .Values.ha.enabled .Values.ha.treeApi.enabled }}
-            - name: EN_TREE_API_PORT
-              value: {{ .Values.ha.treeApi.port | quote }}
-            {{- end }}
             - name: EN_ETH_CLIENT_URL
               value: {{ .Values.node.ethClientUrl | quote }}
             - name: EN_MAIN_NODE_URL
@@ -143,6 +109,13 @@ spec:
               value: "warn,zksync=info,zksync_web3_decl::client=error"
             - name: EN_API_NAMESPACES
               value: {{ .Values.rpc.api | quote }}
+            {{- if or .Values.ha.treeApi.enabled .Values.ha.api.treeApiUrl }}
+            {{- $treeApiUrl := default (printf "http://%s:%s" (include "abstract-node.haCoreName" .) (.Values.ha.treeApi.port | toString)) .Values.ha.api.treeApiUrl }}
+            - name: EN_API_TREE_API_REMOTE_URL
+              value: {{ $treeApiUrl | quote }}
+            - name: EN_API_WEB3_JSON_RPC_TREE_API_REQUEST_TIMEOUT_SEC
+              value: {{ .Values.ha.treeApi.requestTimeoutSec | quote }}
+            {{- end }}
             {{- if .Values.rpc.maxResponseBodySizeMb }}
             - name: EN_MAX_RESPONSE_BODY_SIZE_MB
               value: {{ .Values.rpc.maxResponseBodySizeMb | quote }}
@@ -156,7 +129,7 @@ spec:
               value: {{ .Values.node.batchCommitDataGeneratorMode | quote }}
             {{- end }}
             {{- if .Values.node.daClient }}
-            - name: EN_DA_CLIENT  
+            - name: EN_DA_CLIENT
               value: {{ .Values.node.daClient | quote }}
             {{- end }}
             {{- if and .Values.node.daClient .Values.node.daClientType }}
@@ -187,12 +160,6 @@ spec:
             - name: EN_EXPERIMENTAL_SNAPSHOTS_RECOVERY_L1_BATCH
               value: {{ .Values.node.experimentalSnapshotsRecoveryL1Batch | quote }}
             {{- end }}
-            {{- if .Values.consensus.enabled }}
-            - name: EN_CONSENSUS_CONFIG_PATH
-              value: "/consensus/config.yaml"
-            - name: EN_CONSENSUS_SECRETS_PATH
-              value: "/consensus/secrets.yaml"
-            {{- end }}
             {{- if .Values.node.statekeeper.l2BlockCommitDeadline }}
             - name: EN_STATE_KEEPER_L2_BLOCK_COMMIT_DEADLINE
               value: {{ .Values.node.statekeeper.l2BlockCommitDeadline | quote }}
@@ -210,11 +177,11 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
           ports:
-          {{- if and (not .Values.ha.enabled) .Values.rpc.http.enabled }}
+          {{- if .Values.rpc.http.enabled }}
             - name: http
               containerPort: {{ .Values.rpc.http.port }}
           {{- end }}
-          {{- if and (not .Values.ha.enabled) .Values.rpc.ws.enabled }}
+          {{- if .Values.rpc.ws.enabled }}
             - name: ws
               containerPort: {{ .Values.rpc.ws.port }}
           {{- end }}
@@ -226,45 +193,11 @@ spec:
             - name: healthcheck
               containerPort: {{ .Values.healthcheck.port }}
           {{- end }}
-          {{- if and .Values.ha.enabled .Values.ha.treeApi.enabled }}
-            - name: tree-api
-              containerPort: {{ .Values.ha.treeApi.port }}
-          {{- end }}
-          {{- if .Values.consensus.enabled }}
-            - name: consensus
-              containerPort: {{ .Values.consensus.port }}
-            - name: debug-page
-              containerPort: {{ .Values.consensus.debugPagePort }}
-          {{- end }}
-          {{- if and .Values.ha.enabled .Values.healthcheck.enabled (or .Values.global.readinessProbe.enabled .Values.readinessProbe.enabled) }}
-          readinessProbe:
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            httpGet:
-              path: /health
-              port: healthcheck
-              scheme: HTTP
-          {{- end }}
-          volumeMounts:
-            - name: statekeeper
-              mountPath: /db/ext-node/state_keeper
-            - name: lightweight
-              mountPath: /db/ext-node/lightweight
-            {{- if .Values.consensus.enabled }}
-            - name: consensus-secrets
-              mountPath: /consensus
-            - name: consensus-config
-              mountPath: /consensus/config.yaml
-              subPath: config.yaml
-            {{- end }}
         {{- with .Values.resources }}
           resources:
             {{ toYaml . | nindent 12 | trim }}
         {{- end }}
-      {{- if and (not .Values.ha.enabled) .Values.rpc.http.enabled }}
+      {{- if .Values.rpc.http.enabled }}
         - name: sidecar
           image: "{{ .Values.sidecar.registry }}/{{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}"
           imagePullPolicy: {{ .Values.sidecar.pullPolicy }}
@@ -308,60 +241,4 @@ spec:
               scheme: {{ .Values.readinessProbe.httpGet.scheme }}
         {{- end }}
       {{- end }}
-      volumes:
-{{- if (not .Values.persistence.enabled) }}
-        - name: statekeeper
-          emptyDir: {}
-        - name: lightweight
-          emptyDir: {}
-        {{- if .Values.consensus.enabled }}
-        - name: consensus-secrets
-          emptyDir: {}
-        {{- end }}
-{{- else }}
-  volumeClaimTemplates:
-    {{- if .Values.consensus.enabled }}
-    - metadata:
-        name: consensus-secrets
-        labels:
-          {{- include "common.labels.statefulset" . | nindent 10 }}
-      {{- with .Values.persistence.annotations }}
-        annotations:
-          {{ toYaml . | nindent 10 | trim }}
-      {{- end }}
-      spec:
-        accessModes: {{ .Values.persistence.accessModes }}
-        storageClassName: {{ .Values.persistence.storageClassName }}
-        resources:
-          requests:
-            storage: {{ .Values.persistence.consensus.size | quote }}
-    {{- end }}
-    - metadata:
-        name: lightweight
-        labels:
-          {{- include "common.labels.statefulset" . | nindent 10 }}
-      {{- with .Values.persistence.annotations }}
-        annotations:
-          {{ toYaml . | nindent 10 | trim }}
-      {{- end }}
-      spec:
-        accessModes: {{ .Values.persistence.accessModes }}
-        storageClassName: {{ .Values.persistence.storageClassName }}
-        resources:
-          requests:
-            storage: {{ .Values.persistence.lightweight.size | quote }}
-    - metadata:
-        name: statekeeper
-        labels:
-          {{- include "common.labels.statefulset" . | nindent 10 }}
-      {{- with .Values.persistence.annotations }}
-        annotations:
-          {{ toYaml . | nindent 10 | trim }}
-      {{- end }}
-      spec:
-        accessModes: {{ .Values.persistence.accessModes }}
-        storageClassName: {{ .Values.persistence.storageClassName }}
-        resources:
-          requests:
-            storage: {{ .Values.persistence.statekeeper.size | quote }}
 {{- end }}

--- a/charts/abstract-node/templates/pdb.yaml
+++ b/charts/abstract-node/templates/pdb.yaml
@@ -15,4 +15,7 @@ spec:
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}
+      {{- if .Values.ha.enabled }}
+      app.kubernetes.io/component: api
+      {{- end }}
 {{- end }}

--- a/charts/abstract-node/templates/service-core.yaml
+++ b/charts/abstract-node/templates/service-core.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ha.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "abstract-node.haCoreName" . }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: core
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  {{- if .Values.global.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+  {{- end }}
+  {{- if .Values.healthcheck.enabled }}
+    - name: healthcheck
+      port: {{ .Values.healthcheck.port }}
+      targetPort: healthcheck
+  {{- end }}
+  {{- if .Values.ha.treeApi.enabled }}
+    - name: tree-api
+      port: {{ .Values.ha.treeApi.port }}
+      targetPort: tree-api
+  {{- end }}
+  {{- if .Values.consensus.enabled }}
+    - name: consensus
+      port: {{ .Values.consensus.port }}
+      targetPort: consensus
+    - name: debug-page
+      port: {{ .Values.consensus.debugPagePort }}
+      targetPort: debug-page
+  {{- end }}
+  selector:
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: core
+{{- end }}

--- a/charts/abstract-node/templates/service.yaml
+++ b/charts/abstract-node/templates/service.yaml
@@ -6,8 +6,11 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.ha.enabled }}
+    app.kubernetes.io/component: api
+    {{- end }}
 spec:
-{{- if .Values.svcHeadless }}
+{{- if ternary .Values.ha.api.service.headless .Values.svcHeadless .Values.ha.enabled }}
   clusterIP: None
 {{- end }}
   type: ClusterIP
@@ -34,4 +37,7 @@ spec:
   {{- end }}
   selector:
     {{- include "common.labels.matchLabels" . | nindent 4 }}
+    {{- if .Values.ha.enabled }}
+    app.kubernetes.io/component: api
+    {{- end }}
 {{- end }}

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -84,6 +84,46 @@ image:
 shutdownWrapper:
   enabled: false
 
+## Additional arguments for the single-instance external node container.
+## In HA mode, use ha.core.extraArgs / ha.api.extraArgs instead.
+##
+args: []
+
+## High-availability mode splits the external node into:
+## - one StatefulSet pod running core/tree components with RocksDB persistence
+## - a Deployment running one or more API-only replicas
+##
+ha:
+  enabled: false
+  core:
+    ## Components for the singleton StatefulSet pod. Leave empty to use the
+    ## default, which is core,tree,tree_fetcher,tree_api when ha.treeApi.enabled
+    ## is true, otherwise core,tree,tree_fetcher.
+    ##
+    components: ""
+    extraArgs: []
+  api:
+    replicaCount: 2
+    ## Components for API replicas. Leave empty to use "api".
+    ##
+    components: ""
+    extraArgs: []
+    service:
+      ## API service defaults to a normal ClusterIP service for load balancing.
+      ##
+      headless: false
+    ## Optional override for the remote tree API URL used by API replicas.
+    ## When empty and ha.treeApi.enabled is true, the chart points API replicas
+    ## at the HA core service.
+    ##
+    treeApiUrl: ""
+  treeApi:
+    ## Runs tree_api with the core pod and wires API replicas to it.
+    ##
+    enabled: true
+    port: "3072"
+    requestTimeoutSec: 60
+
 # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 ## Provide a name in place of abstract-node for `app:` labels


### PR DESCRIPTION
## What changed

Adds an opt-in HA mode for the `abstract-node` Helm chart. HA mode splits the external node into a singleton core StatefulSet running the stateful components and an API Deployment that can scale from one to many replicas.

The default HA core component set runs `core,tree,tree_fetcher,tree_api`, so API replicas can proxy tree-backed proof calls to the core pod. Setting `ha.treeApi.enabled=false` renders the exact `core,tree,tree_fetcher` core component list. The existing non-HA path remains the default for backwards compatibility.

## Impact

Existing chart consumers continue to get the current single StatefulSet behavior unless they set `ha.enabled=true`.

When HA mode is enabled, the public service selects API replicas for load balancing, while a separate headless core service supports StatefulSet DNS, health, metrics, consensus ports, and tree API routing.

## Validation

- `helm lint charts/abstract-node --set database.secretName=db-secret`
- `helm template abstract charts/abstract-node --set database.secretName=db-secret --set ha.enabled=true --set ha.api.replicaCount=3`
- Previously verified default rendering, HA rendering with `ha.treeApi.enabled=false`, and HA rendering with `shutdownWrapper.enabled=true`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the high-availability (HA) features of the `abstract-node` Helm chart, including the addition of HA services, updates to configurations, and improvements in deployment templates.

### Detailed summary
- Updated `version` in `Chart.yaml` from `0.1.39` to `0.1.40`.
- Added HA support in `pdb.yaml`, `service.yaml`, and `service-core.yaml`.
- Introduced new templates for HA core and API services.
- Modified `statefulset.yaml` to conditionally set names and args based on HA.
- Enhanced `deployment-api.yaml` with HA configurations.
- Updated `values.yaml` to include HA settings and parameters.
- Added helper functions in `_helpers.tpl` for HA component names.
- Adjusted readiness and liveness probes to support HA scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->