### PR TITLE
feat(chart): add ha resource overrides

### DIFF
--- a/charts/abstract-node/templates/deployment-api.yaml
+++ b/charts/abstract-node/templates/deployment-api.yaml
@@ -193,7 +193,7 @@ spec:
             - name: healthcheck
               containerPort: {{ .Values.healthcheck.port }}
           {{- end }}
-        {{- with .Values.resources }}
+        {{- with (default .Values.resources .Values.ha.api.resources) }}
           resources:
             {{ toYaml . | nindent 12 | trim }}
         {{- end }}

--- a/charts/abstract-node/templates/statefulset.yaml
+++ b/charts/abstract-node/templates/statefulset.yaml
@@ -260,7 +260,8 @@ spec:
               mountPath: /consensus/config.yaml
               subPath: config.yaml
             {{- end }}
-        {{- with .Values.resources }}
+        {{- $resources := ternary (default .Values.resources .Values.ha.core.resources) .Values.resources .Values.ha.enabled }}
+        {{- with $resources }}
           resources:
             {{ toYaml . | nindent 12 | trim }}
         {{- end }}

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -102,12 +102,20 @@ ha:
     ##
     components: ""
     extraArgs: []
+    ## Resource requests and limits for the core StatefulSet pod.
+    ## Falls back to top-level resources when empty.
+    ##
+    resources: {}
   api:
     replicaCount: 2
     ## Components for API replicas. Leave empty to use "api".
     ##
     components: ""
     extraArgs: []
+    ## Resource requests and limits for API Deployment pods.
+    ## Falls back to top-level resources when empty.
+    ##
+    resources: {}
     service:
       ## API service defaults to a normal ClusterIP service for load balancing.
       ##


### PR DESCRIPTION
## What changed

Adds role-specific resource overrides for HA mode in the `abstract-node` Helm chart:

- `ha.core.resources` for the HA core StatefulSet pod
- `ha.api.resources` for HA API Deployment pods

Both values default to `{}` and fall back to the existing top-level `resources` value when empty, preserving the current chart behavior for existing consumers.

## Impact

HA users can size the stateful core pod separately from the horizontally-scaled API pods. Non-HA users continue to use top-level `resources`; HA users also continue to get top-level `resources` for both roles unless they opt into role-specific overrides.

## Validation

- `helm lint charts/abstract-node --set database.secretName=db-secret`
- `helm template abstract charts/abstract-node --set database.secretName=db-secret --set ha.enabled=true --set resources.requests.cpu=7 --set resources.requests.memory=30Gi --set resources.limits.cpu=7 --set resources.limits.memory=30Gi`
- `helm template abstract charts/abstract-node --set database.secretName=db-secret --set ha.enabled=true --set resources.requests.cpu=7 --set resources.requests.memory=30Gi --set resources.limits.cpu=7 --set resources.limits.memory=30Gi --set ha.api.resources.requests.cpu=1 --set ha.api.resources.requests.memory=4Gi --set ha.api.resources.limits.cpu=2 --set ha.api.resources.limits.memory=8Gi --set ha.core.resources.requests.cpu=6 --set ha.core.resources.requests.memory=28Gi --set ha.core.resources.limits.cpu=6 --set ha.core.resources.limits.memory=28Gi`
- `helm template abstract charts/abstract-node --set database.secretName=db-secret --set resources.requests.cpu=7 --set resources.requests.memory=30Gi --set ha.core.resources.requests.cpu=1 --set ha.api.resources.requests.cpu=1`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing resource management in the Helm chart templates for deployments and stateful sets by introducing fallbacks to hierarchical resource definitions.

### Detailed summary
- Updated `deployment-api.yaml` to use `default` for resources fallback.
- Modified `statefulset.yaml` to utilize `ternary` for conditional resource assignment.
- Added comments in `values.yaml` to clarify resource requests and limits for StatefulSet and Deployment pods.
- Introduced empty `resources` objects in `values.yaml` for both StatefulSet and API Deployment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->