### PR TITLE
Pin en image

### DIFF
--- a/charts/abstract-node/Chart.yaml
+++ b/charts/abstract-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: abstract-node
 description: External node for syncing and serving blockchain data for Abstract
-version: 0.1.45
+version: 0.1.46
 type: application
 icon: https://abstract-assets.abs.xyz/icons/light.png
 keywords:
@@ -11,7 +11,7 @@ keywords:
 home: https://abs.xyz
 sources:
   - https://github.com/matter-labs/zksync-era
-appVersion: "31.1.0"
+appVersion: "f11180bd-1786191203"
 
 dependencies:
   - name: common

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -79,7 +79,7 @@ image:
   registry: docker.io
   repository: matterlabs/external-node
   pullPolicy: IfNotPresent
-  tag: "v31.1.0"
+  tag: "f11180bd-1786191203"
 
 shutdownWrapper:
   enabled: false

--- a/docker/external-node.yml
+++ b/docker/external-node.yml
@@ -52,7 +52,7 @@ services:
   # Generation of consensus secrets.
   # The secrets are generated iff the secrets file doesn't already exist.
   generate-secrets:
-    image: "matterlabs/external-node:${EN_VERSION:-v31.1.0}"
+    image: "matterlabs/external-node:${EN_VERSION:-f11180bd-1786191203}"
     entrypoint:
       [
       "/configs/generate_secrets.sh",
@@ -61,7 +61,7 @@ services:
     volumes:
       - ./configs:/configs
   external-node:
-    image: "matterlabs/external-node:${EN_VERSION:-v31.1.0}"
+    image: "matterlabs/external-node:${EN_VERSION:-f11180bd-1786191203}"
     entrypoint: ["/usr/bin/entrypoint.sh"]
     restart: always
     depends_on:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the versioning and image tags for the `abstract-node` charts and related configurations to a new commit identifier.

### Detailed summary
- Updated `tag` in `charts/abstract-node/values.yaml` from `"v31.1.0"` to `"f11180bd-1786191203"`.
- Bumped `version` in `charts/abstract-node/Chart.yaml` from `0.1.45` to `0.1.46`.
- Changed `appVersion` in `charts/abstract-node/Chart.yaml` from `"31.1.0"` to `"f11180bd-1786191203"`.
- Updated `image` in `docker/external-node.yml` from `"matterlabs/external-node:v31.1.0"` to `"matterlabs/external-node:f11180bd-1786191203"` for `generate-secrets` and `external-node` services.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->