### PR TITLE
Gate native stopSignal behind explicit opt-in

### DIFF
--- a/charts/abstract-node/Chart.yaml
+++ b/charts/abstract-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: abstract-node
 description: External node for syncing and serving blockchain data for Abstract
-version: 0.1.46
+version: 0.1.47
 type: application
 icon: https://abstract-assets.abs.xyz/icons/light.png
 keywords:

--- a/charts/abstract-node/templates/_helpers.tpl
+++ b/charts/abstract-node/templates/_helpers.tpl
@@ -127,7 +127,7 @@ Render external node command / args, preserving the existing shutdown wrapper be
 {{- $root := .root -}}
 {{- $args := default (list) .args -}}
 {{- $kubeVersion := $root.Capabilities.KubeVersion.Version | trimPrefix "v" -}}
-{{- $supportsStopSignal := semverCompare ">=1.33.0-0" $kubeVersion -}}
+{{- $supportsStopSignal := and $root.Values.shutdownWrapper.nativeStopSignal.enabled (semverCompare ">=1.33.0-0" $kubeVersion) -}}
 {{- if and $root.Values.shutdownWrapper.enabled (not $supportsStopSignal) }}
 command:
   - /bin/sh

--- a/charts/abstract-node/templates/deployment-api.yaml
+++ b/charts/abstract-node/templates/deployment-api.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ha.enabled }}
 {{- $kubeVersion := .Capabilities.KubeVersion.Version | trimPrefix "v" -}}
-{{- $supportsStopSignal := semverCompare ">=1.33.0-0" $kubeVersion -}}
+{{- $supportsStopSignal := and .Values.shutdownWrapper.nativeStopSignal.enabled (semverCompare ">=1.33.0-0" $kubeVersion) -}}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/abstract-node/templates/statefulset.yaml
+++ b/charts/abstract-node/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- $kubeVersion := .Capabilities.KubeVersion.Version | trimPrefix "v" -}}
-{{- $supportsStopSignal := semverCompare ">=1.33.0-0" $kubeVersion -}}
+{{- $supportsStopSignal := and .Values.shutdownWrapper.nativeStopSignal.enabled (semverCompare ">=1.33.0-0" $kubeVersion) -}}
 ---
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -83,6 +83,8 @@ image:
 
 shutdownWrapper:
   enabled: false
+  nativeStopSignal:
+    enabled: false
 
 ## Additional arguments for the single-instance external node container.
 ## In HA mode, use ha.core.extraArgs / ha.api.extraArgs instead.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a `nativeStopSignal` configuration option to the `shutdownWrapper` in the `abstract-node` charts, allowing for more granular control over shutdown signals based on Kubernetes version compatibility.

### Detailed summary
- Added `nativeStopSignal` configuration under `shutdownWrapper` in `charts/abstract-node/values.yaml`.
- Updated version in `charts/abstract-node/Chart.yaml` from `0.1.46` to `0.1.47`.
- Modified `supportsStopSignal` logic in `statefulset.yaml`, `deployment-api.yaml`, and `_helpers.tpl` to depend on `shutdownWrapper.nativeStopSignal.enabled`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->