### PR TITLE
fix: make external node compose portable

### DIFF
--- a/docker/external-node.yml
+++ b/docker/external-node.yml
@@ -1,4 +1,3 @@
-name: "abstract-${NETWORK}-external-node"
 services:
   prometheus:
     image: prom/prometheus:v2.35.0
@@ -94,7 +93,7 @@ services:
       EN_MAIN_NODE_URL: ${EN_MAIN_NODE_URL:-https://api.mainnet.abs.xyz}
       EN_L1_CHAIN_ID: ${EN_L1_CHAIN_ID:-1}
       EN_L2_CHAIN_ID: ${EN_L2_CHAIN_ID:-2741}
-      EN_PRUNING_ENABLED: ${EN_PRUNING_ENABLED:-true}
+      EN_PRUNING_ENABLED: "${EN_PRUNING_ENABLED:-true}"
 
       EN_GAS_PRICE_SCALE_FACTOR: "1.5"
       EN_ESTIMATE_GAS_SCALE_FACTOR: "1.3"


### PR DESCRIPTION
Addresses issue #6.

Make the external-node Compose file portable across current Compose implementations. Remove the legacy-incompatible top-level name field and quote the boolean pruning environment value so interpolation preserves a string-compatible value.

Validation:
- YAML parsing passed.
- - Compose structure check passed: five services, no top-level name, and string-compatible pruning value.
- - git diff --check passed.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `EN_PRUNING_ENABLED` environment variable format in the `docker/external-node.yml` file to ensure it is enclosed in quotes.

### Detailed summary
- Changed the format of `EN_PRUNING_ENABLED` from `${EN_PRUNING_ENABLED:-true}` to `"${EN_PRUNING_ENABLED:-true}"` in `docker/external-node.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->