### PR TITLE
Update en image

### DIFF
--- a/charts/abstract-node/Chart.yaml
+++ b/charts/abstract-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: abstract-node
 description: External node for syncing and serving blockchain data for Abstract
-version: 0.1.47
+version: 0.1.48
 type: application
 icon: https://abstract-assets.abs.xyz/icons/light.png
 keywords:
@@ -11,7 +11,7 @@ keywords:
 home: https://abs.xyz
 sources:
   - https://github.com/matter-labs/zksync-era
-appVersion: "f11180bd-1786191203"
+appVersion: "9734bf2-1787057993929"
 
 dependencies:
   - name: common

--- a/charts/abstract-node/templates/_helpers.tpl
+++ b/charts/abstract-node/templates/_helpers.tpl
@@ -62,6 +62,19 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+External node image, optionally pinned by digest.
+*/}}
+{{- define "abstract-node.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $image := printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
+{{- with .Values.image.digest -}}
+{{- printf "%s@%s" $image . -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Render OpenTelemetry environment variables for the external node container.
 */}}
 {{- define "abstract-node.otelEnv" -}}

--- a/charts/abstract-node/templates/deployment-api.yaml
+++ b/charts/abstract-node/templates/deployment-api.yaml
@@ -56,7 +56,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "abstract-node.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if $supportsStopSignal }}
           lifecycle:

--- a/charts/abstract-node/templates/statefulset.yaml
+++ b/charts/abstract-node/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
       {{- if .Values.consensus.enabled }}
       initContainers:
       - name: init-consensus-secrets
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "abstract-node.image" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - "/bin/sh"
@@ -82,7 +82,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "abstract-node.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if $supportsStopSignal }}
           lifecycle:

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -79,7 +79,8 @@ image:
   registry: docker.io
   repository: matterlabs/external-node
   pullPolicy: IfNotPresent
-  tag: "f11180bd-1786191203"
+  tag: "9734bf2-1787057993929"
+  digest: "sha256:0bbcb2ffceca37f9f2b0d4e0f243b2fe636f4080103f62b50419f67a77d8f60a"
 
 shutdownWrapper:
   enabled: false

--- a/docker/external-node.yml
+++ b/docker/external-node.yml
@@ -52,7 +52,7 @@ services:
   # Generation of consensus secrets.
   # The secrets are generated iff the secrets file doesn't already exist.
   generate-secrets:
-    image: "matterlabs/external-node:${EN_VERSION:-f11180bd-1786191203}"
+    image: "matterlabs/external-node:${EN_VERSION:-9734bf2-1787057993929}@${EN_DIGEST:-sha256:0bbcb2ffceca37f9f2b0d4e0f243b2fe636f4080103f62b50419f67a77d8f60a}"
     entrypoint:
       [
       "/configs/generate_secrets.sh",
@@ -61,7 +61,7 @@ services:
     volumes:
       - ./configs:/configs
   external-node:
-    image: "matterlabs/external-node:${EN_VERSION:-f11180bd-1786191203}"
+    image: "matterlabs/external-node:${EN_VERSION:-9734bf2-1787057993929}@${EN_DIGEST:-sha256:0bbcb2ffceca37f9f2b0d4e0f243b2fe636f4080103f62b50419f67a77d8f60a}"
     entrypoint: ["/usr/bin/entrypoint.sh"]
     restart: always
     depends_on:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the versioning and image management for the `abstract-node` Helm chart, including changes to image tags, digests, and the introduction of a helper function for image generation.

### Detailed summary
- Updated `tag` and `appVersion` in `charts/abstract-node/values.yaml` to `9734bf2-1787057993929`.
- Added `digest` to `values.yaml`.
- Replaced image definition in `deployment-api.yaml`, `statefulset.yaml`, and `initContainers` with a new helper function `abstract-node.image`.
- Updated version in `charts/abstract-node/Chart.yaml` to `0.1.48`.
- Modified image references in `docker/external-node.yml` to include the new tag and digest.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->