### PR TITLE
fix: add missing consensus-config ConfigMap volume to StatefulSet

### DIFF
--- a/charts/abstract-node/templates/statefulset.yaml
+++ b/charts/abstract-node/templates/statefulset.yaml
@@ -323,6 +323,11 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
+        {{- if .Values.consensus.enabled }}
+        - name: consensus-config
+          configMap:
+            name: {{ include "common.names.fullname" . }}-consensus
+        {{- end }}
 {{- if (not .Values.persistence.enabled) }}
         - name: statekeeper
           emptyDir: {}


### PR DESCRIPTION
When consensus.enabled is true, the StatefulSet mounts a volume named consensus config but no corresponding volume is defined. This causes pod creation to fail with 'volume consensus-config not found'.

The consensus ConfigMap is already created by configmap consensus.yaml but was never referenced as a volume source in the StatefulSet.

Add the ConfigMap volume above the persistence check so it is available in both persistent and non-persistent modes.

Fixes #33

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new volume configuration for a `consensus config` in the `statefulset.yaml` template, contingent on the `consensus.enabled` value. It also removes the `statekeeper` volume when persistence is not enabled.

### Detailed summary
- Added a new volume named `consensus config` that uses a `configMap`.
- The `consensus-config` volume is conditionally included based on `.Values.consensus.enabled`.
- Removed the `statekeeper` volume definition when persistence is not enabled.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->