### PR TITLE
fix: rename RethNodeDown alert to AbstractExternalNodeDown

### DIFF
--- a/charts/abstract-node/templates/prometheusrules.yaml
+++ b/charts/abstract-node/templates/prometheusrules.yaml
@@ -23,13 +23,13 @@ spec:
   {{- if .Values.metrics.prometheusRule.default }}
     - name: {{ include "common.names.fullname" $ }}-default
       rules:
-        - alert: RethNodeDown
+        - alert: AbstractExternalNodeDown
           expr: up{job="{{ include "common.names.fullname" . }}"} == 0
           for: 5m
           labels:
             severity: critical
           annotations:
-            summary: Reth Node {{ printf "{{ $labels.instance }}" }} down
-            description: Reth Node {{ printf "{{ $labels.instance }}" }} is down
+            summary: Abstract External Node {{ printf "{{ $labels.instance }}" }} down
+            description: Abstract External Node {{ printf "{{ $labels.instance }}" }} is down
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes #34

The default PrometheusRule alert is named `RethNodeDown` with annotations referencing "Reth Node". Abstract is a zkSync-based L2 running `matterlabs/external-node` not Reth. This was a copy-paste artifact from a Reth-based chart template.

Renames the alert and updates summary/description annotations to correctly reference the Abstract External Node.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the alert configuration in the `prometheusrules.yaml` file for a monitoring system. It changes the alert name and updates the summary and description to reflect a new context related to an external node.

### Detailed summary
- Changed alert name from `RethNodeDown` to `AbstractExternalNodeDown`.
- Updated summary from `Reth Node {{ printf "{{ $labels.instance }}" }} down` to `Abstract External Node {{ printf "{{ $labels.instance }}" }} down`.
- Updated description from `Reth Node {{ printf "{{ $labels.instance }}" }} is down` to `Abstract External Node {{ printf "{{ $labels.instance }}" }} is down`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->