### PR TITLE
Fix latest release image

### DIFF
--- a/charts/abstract-node/Chart.yaml
+++ b/charts/abstract-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: abstract-node
 description: External node for syncing and serving blockchain data for Abstract
-version: 0.1.48
+version: 0.1.49
 type: application
 icon: https://abstract-assets.abs.xyz/icons/light.png
 keywords:

--- a/charts/abstract-node/values.yaml
+++ b/charts/abstract-node/values.yaml
@@ -80,7 +80,7 @@ image:
   repository: matterlabs/external-node
   pullPolicy: IfNotPresent
   tag: "9734bf2-1787057993929"
-  digest: "sha256:0bbcb2ffceca37f9f2b0d4e0f243b2fe636f4080103f62b50419f67a77d8f60a"
+  digest: "sha256:5dadc06bdf3bb09b7ac508e6761e164bca22fae09860cf8bc57041302f80f40b"
 
 shutdownWrapper:
   enabled: false

--- a/docker/external-node.yml
+++ b/docker/external-node.yml
@@ -52,7 +52,7 @@ services:
   # Generation of consensus secrets.
   # The secrets are generated iff the secrets file doesn't already exist.
   generate-secrets:
-    image: "matterlabs/external-node:${EN_VERSION:-9734bf2-1787057993929}@${EN_DIGEST:-sha256:0bbcb2ffceca37f9f2b0d4e0f243b2fe636f4080103f62b50419f67a77d8f60a}"
+    image: "matterlabs/external-node:${EN_VERSION:-9734bf2-1787057993929}@${EN_DIGEST:-sha256:5dadc06bdf3bb09b7ac508e6761e164bca22fae09860cf8bc57041302f80f40b}"
     entrypoint:
       [
       "/configs/generate_secrets.sh",
@@ -61,7 +61,7 @@ services:
     volumes:
       - ./configs:/configs
   external-node:
-    image: "matterlabs/external-node:${EN_VERSION:-9734bf2-1787057993929}@${EN_DIGEST:-sha256:0bbcb2ffceca37f9f2b0d4e0f243b2fe636f4080103f62b50419f67a77d8f60a}"
+    image: "matterlabs/external-node:${EN_VERSION:-9734bf2-1787057993929}@${EN_DIGEST:-sha256:5dadc06bdf3bb09b7ac508e6761e164bca22fae09860cf8bc57041302f80f40b}"
     entrypoint: ["/usr/bin/entrypoint.sh"]
     restart: always
     depends_on:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version and digest of the `abstract-node` chart and the corresponding `external-node` image in the configuration files.

### Detailed summary
- Updated `version` in `charts/abstract-node/Chart.yaml` from `0.1.48` to `0.1.49`.
- Changed `digest` in `charts/abstract-node/values.yaml` to a new SHA256 hash.
- Updated the `image` digest in `docker/external-node.yml` for the `generate-secrets` and `external-node` sections.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->