### PR TITLE
fix: Grafana Prometheus datasource UID

### DIFF
--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -5,6 +5,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
+    uid: PBFA97CFB590B2093
     url: http://prometheus:9090
     isDefault: true
     editable: true


### PR DESCRIPTION
`General.json` references the Prometheus datasource using UID `PBFA97CFB590B2093`, but `prometheus.yml` did not explicitly define it.

Added the same UID to the datasource provisioning config to keep it consistent with the dashboard references and ensure the datasource UID is explicitly defined.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `prometheus.yml` configuration file for Grafana's data source provisioning by adding a unique identifier (UID) for the Prometheus data source.

### Detailed summary
- Added a new line with `uid: PBFA97CFB590B2093` to the `prometheus.yml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->