### PR TITLE
fix: quote boolean environment variables in docker-compose

### DIFF
--- a/docker/external-node.yml
+++ b/docker/external-node.yml
@@ -94,7 +94,7 @@ services:
       EN_MAIN_NODE_URL: ${EN_MAIN_NODE_URL:-https://api.mainnet.abs.xyz}
       EN_L1_CHAIN_ID: ${EN_L1_CHAIN_ID:-1}
       EN_L2_CHAIN_ID: ${EN_L2_CHAIN_ID:-2741}
-      EN_PRUNING_ENABLED: ${EN_PRUNING_ENABLED:-true}
+      EN_PRUNING_ENABLED: "${EN_PRUNING_ENABLED:-true}"
 
       EN_GAS_PRICE_SCALE_FACTOR: "1.5"
       EN_ESTIMATE_GAS_SCALE_FACTOR: "1.3"
@@ -102,7 +102,7 @@ services:
 
       EN_STATE_CACHE_PATH: "./db/ext-node/state_keeper"
       EN_MERKLE_TREE_PATH: "./db/ext-node/lightweight"
-      EN_SNAPSHOTS_RECOVERY_ENABLED: ${EN_SNAPSHOTS_RECOVERY_ENABLED:-true}
+      EN_SNAPSHOTS_RECOVERY_ENABLED: "${EN_SNAPSHOTS_RECOVERY_ENABLED:-true}"
       EN_SNAPSHOTS_OBJECT_STORE_BUCKET_BASE_URL: ${EN_SNAPSHOTS_OBJECT_STORE_BUCKET_BASE_URL:-raas-abstract-mainnet-external-node-snapshots}
       EN_SNAPSHOTS_OBJECT_STORE_MODE: "GCSAnonymousReadOnly"
       RUST_LOG: ${RUST_LOG:-warn,zksync=info,zksync_core::metadata_calculator=debug,zksync_state=debug,zksync_utils=debug,zksync_web3_decl::client=error}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `docker/external-node.yml` configuration file by changing certain environment variable assignments to use quotes, ensuring consistent formatting.

### Detailed summary
- Changed `EN_PRUNING_ENABLED` assignment from `${EN_PRUNING_ENABLED:-true}` to `"${EN_PRUNING_ENABLED:-true}"`
- Changed `EN_SNAPSHOTS_RECOVERY_ENABLED` assignment from `${EN_SNAPSHOTS_RECOVERY_ENABLED:-true}` to `"${EN_SNAPSHOTS_RECOVERY_ENABLED:-true}"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->